### PR TITLE
Use htmlparser2 directly for memory/speed gains

### DIFF
--- a/bin/feed-discover.js
+++ b/bin/feed-discover.js
@@ -8,7 +8,7 @@ var valid = require('is-url')
 
 var sanitise = function(url) {
   if (!url) {
-    return null 
+    return null
   }
 
   var has = parse(url)
@@ -35,9 +35,9 @@ var fail = function(error) {
       url + ' doesn’t seem to exist.' :
 
     error.code === 'ECONNREFUSED' ?
-    'The connection was refused.' + 
+    'The connection was refused.' +
     (https ? ' Maybe try regular old http.' : '') :
-  
+
     'S̵om̴e̷͢t͏̧h̨i͟n͢͢ģ͜ ̢͟w̴̴e̵͟͝nt̛͡͝ ̧͠h̕͏o̷rríbĺ͘y̶̨ w̵̴̨ŗo̢͏n̴̸͠g̷…͠'
   )
 

--- a/index.js
+++ b/index.js
@@ -29,18 +29,18 @@ Discover.prototype.feeds = function(buffer) {
     var feed = $(this).attr('href')
     feeds.push(feed)
   }
-  
+
   if (this.dregs) {
     html = this.dregs + html
   }
-  
+
   // Don't lose tags that were split apart
   // in the process of being streamed.
-  var lines = html.split(/\n|\r/) 
+  var lines = html.split(/\n|\r/)
   this.dregs = lines.slice(lines.length - 2).join('')
 
   var $ = cheerio.load(html)
-  
+
   // Legit
   $('link[type*=rss]').each(extract)
   $('link[type*=atom]').each(extract)
@@ -48,7 +48,7 @@ Discover.prototype.feeds = function(buffer) {
   // Questionable
   $('a:contains(RSS)').each(extract)
   $('a[href*=feedburner]').each(extract)
-  
+
   return feeds
 }
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "as-stream": "~0.1.1",
-    "cheerio": "~0.12.4",
-    "is-url": "~1.0.0",
-    "request": "~2.27.0"
+    "htmlparser2": "^3.9.1",
+    "is-url": "^1.2.2",
+    "request": "^2.74.0"
   },
   "devDependencies": {
     "tape": "~2.1.0",


### PR DESCRIPTION
Hi, thanks for this project, I've found it useful.  

I noticed that feed-discover uses cheerio and I wanted to optimise it out since finding feeds doesn't requite most of cheerio's functionality and cheerio itself has 16 dependencies.  Instead I've switched to using htmlparser2 directly, which cheerio also depends on, so these changes strictly reduce the number of dependencies.

Running the tests with these changes, total memory usage is down 10MB, heap size is down 8MB and it's about 30% faster.

This patch sacrifices the :contains() selector to look for links with the words 'RSS' in them, which as marked in the code originally was 'questionable' so didn't seem like much of a loss.  It also changes the URL resolving behaviour - it seems to me that URLs should be resolved relative to the URL of the page being read, not the root of the site.  And at the old line 59, I couldn't find any way to get url.resolve() to produce URLs starting in '//' so I removed that test too.

Feel free to use or not :)
